### PR TITLE
Fix typos in initialization references

### DIFF
--- a/docs/docs/integrations/llms/clarifai.ipynb
+++ b/docs/docs/integrations/llms/clarifai.ipynb
@@ -128,7 +128,7 @@
     "\n",
     "You will have to also initialize the model id and if needed, the model version id. Some models have many versions, you can choose the one appropriate for your task.\n",
     "                                                              \n",
-    "Alternatively, You can use the model_url (for ex: \"https://clarifai.com/anthropic/completion/models/claude-v2\") for intialization."
+    "Alternatively, You can use the model_url (for ex: \"https://clarifai.com/anthropic/completion/models/claude-v2\") for initialization."
    ]
   },
   {

--- a/libs/community/langchain_community/vectorstores/documentdb.py
+++ b/libs/community/langchain_community/vectorstores/documentdb.py
@@ -327,7 +327,7 @@ class DocumentDBVectorSearch(VectorStore):
         Returns:
             A list of documents closest to the query vector
         """
-        # $match can't be null, so intializes to {} when None to avoid
+        # $match can't be null, so initializes to {} when None to avoid
         # "the match filter must be an expression in an object"
         if not filter:
             filter = {}

--- a/libs/community/langchain_community/vectorstores/falkordb_vector.py
+++ b/libs/community/langchain_community/vectorstores/falkordb_vector.py
@@ -1152,7 +1152,7 @@ class FalkorDBVector(VectorStore):
         Args:
             embedding: The `Embeddings` model you would like to use
             database: The name of the existing graph/database you
-              would like to intialize
+              would like to initialize
             node_label: The label of the node you want to initialize.
             embedding_node_property: The name of the property you
               want your embeddings to be stored in.

--- a/libs/partners/openai/tests/unit_tests/embeddings/test_azure_embeddings.py
+++ b/libs/partners/openai/tests/unit_tests/embeddings/test_azure_embeddings.py
@@ -15,7 +15,7 @@ def test_initialize_azure_openai() -> None:
     assert embeddings.model == "text-embedding-large"
 
 
-def test_intialize_azure_openai_with_base_set() -> None:
+def test_initialize_azure_openai_with_base_set() -> None:
     with mock.patch.dict(os.environ, {"OPENAI_API_BASE": "https://api.openai.com"}):
         embeddings = AzureOpenAIEmbeddings(  # type: ignore[call-arg, call-arg]
             model="text-embedding-large",


### PR DESCRIPTION
## Summary
- fix docs to use `initialization`
- fix `intialize` wording in FalkorDB vector docstring
- fix `intializes` typo in DocumentDB vector store
- update test name with `initialize`

## Testing
- `make test TEST_FILE=tests/unit_tests/embeddings/test_azure_embeddings.py` in `libs/partners/openai`
- `make test TEST_FILE=tests/unit_tests/vectorstores/test_falkordb_vector_utils.py` in `libs/community`
- `make test` (full community suite) *(fails: test_llamafile missing server)*

------
https://chatgpt.com/codex/tasks/task_e_684331b04a188331a0b95cdb9bfd8c8a