### PR TITLE
Fix Clickup create_folder assigns folder_id

### DIFF
--- a/libs/community/langchain_community/utilities/clickup.py
+++ b/libs/community/langchain_community/utilities/clickup.py
@@ -590,7 +590,7 @@ found in task keys {task.keys()}. Please call again with one of the key names.""
         data = response.json()
 
         if "id" in data:
-            self.list_id = data["id"]
+            self.folder_id = data["id"]
         return data
 
     def run(self, mode: str, query: str) -> str:

--- a/libs/community/tests/unit_tests/utilities/test_clickup.py
+++ b/libs/community/tests/unit_tests/utilities/test_clickup.py
@@ -1,0 +1,29 @@
+import json
+from typing import Any
+
+import pytest
+
+from langchain_community.utilities.clickup import ClickupAPIWrapper
+
+
+@pytest.fixture
+def wrapper(mocker: Any) -> ClickupAPIWrapper:
+    mocker.patch("langchain_community.utilities.clickup.fetch_team_id", return_value="1")
+    mocker.patch("langchain_community.utilities.clickup.fetch_space_id", return_value="2")
+    mocker.patch("langchain_community.utilities.clickup.fetch_folder_id", return_value="3")
+    mocker.patch("langchain_community.utilities.clickup.fetch_list_id", return_value="4")
+    return ClickupAPIWrapper(access_token="token")
+
+
+def test_create_folder_updates_folder_id(mocker: Any, wrapper: ClickupAPIWrapper) -> None:
+    mock_response = mocker.Mock()
+    mock_response.json.return_value = {"id": 5, "name": "folder"}
+    mocker.patch("langchain_community.utilities.clickup.requests.post", return_value=mock_response)
+
+    assert wrapper.folder_id == "3"
+    assert wrapper.list_id == "4"
+
+    wrapper.create_folder(json.dumps({"name": "folder"}))
+
+    assert wrapper.folder_id == 5
+    assert wrapper.list_id == "4"


### PR DESCRIPTION
## Summary
- create_folder should set `folder_id` not `list_id`
- add unit test for create_folder

## Testing
- `pytest libs/community/tests/unit_tests/utilities/test_clickup.py -q -c /dev/null`

------
https://chatgpt.com/codex/tasks/task_e_684331b7e730833182d83a34722cbbea